### PR TITLE
btf: add function type support

### DIFF
--- a/btf.h
+++ b/btf.h
@@ -64,8 +64,10 @@ struct btf_type {
 #define BTF_KIND_VOLATILE	9	/* Volatile	*/
 #define BTF_KIND_CONST		10	/* Const	*/
 #define BTF_KIND_RESTRICT	11	/* Restrict	*/
-#define BTF_KIND_MAX		11
-#define NR_BTF_KINDS		12
+#define BTF_KIND_FUNC		12	/* Function     */
+#define BTF_KIND_FUNC_PROTO	13	/* Function Prototype	*/
+#define BTF_KIND_MAX		13
+#define NR_BTF_KINDS		14
 
 /* For some specific BTF_KIND, "struct btf_type" is immediately
  * followed by extra data.

--- a/libbtf.h
+++ b/libbtf.h
@@ -4,6 +4,7 @@
 #include "gobuffer.h"
 
 #include <stdint.h>
+#include <stdbool.h>
 
 struct btf {
 	union {
@@ -38,6 +39,10 @@ int btf__add_member(struct btf *btf, uint32_t name, uint32_t type,
 		    uint32_t bit_offset);
 int32_t btf__add_struct(struct btf *btf, uint8_t kind, uint32_t name,
 			uint32_t size, uint16_t nr_members);
+int32_t btf__add_func_param(struct btf *btf, uint32_t name,
+			    uint32_t type);
+int32_t btf__add_func(struct btf *btf, uint32_t name, uint32_t return_type,
+		      uint16_t nr_params, bool is_proto);
 int32_t btf__add_array(struct btf *btf, uint32_t type, uint32_t index_type,
 		       uint32_t nelems);
 int32_t btf__add_enum(struct btf *btf, uint32_t name, uint32_t size,


### PR DESCRIPTION
This patch adds BTF_KIND_FUNC and BTF_KIND_FUNC_PROTO
support to the type section. The BTF_KIND_FUNC is the type
for dwarf subprogram tag which represents a defined subprogram,
and the BTF_KIND_FUNC_PROTO is the type for dwarf subroutine_type
which represents the pointee of a function pointer.

The func return type is in t->type (where t is a "struct btf_type"
object).  The func args are an array of u32s immediately
following object "t".

Signed-off-by: Okash Khawaja <osk@fb.com>
Signed-off-by: Yonghong Song <yhs@fb.com>